### PR TITLE
Added buffer support for pipeline.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -93,6 +93,10 @@ Once workerPoolSize is reached, worker goroutines will compete for the inputs
 from the producer until the pipeline is done. The pool will not auto shrink for
 simplicity reasons.
 
+The bufferSize parameter defines the buffer size of the output channel. This
+allows the processing to start without having to block wait on the consumer to
+start reading.
+
 Chaining Pipelines
 
 A Pipeline also has a set of APIs to make pipeline chaining straight-forward.
@@ -114,6 +118,38 @@ with the Consumes method.
 
 Examples of composing pipelines can be found in the example of the Produces
 method.
+
+Performance Tuning
+
+There are 3 important dials that would help fine tune the performance
+characteristics of a pipeline: the buffer size of the producer, workerPoolSize
+and bufferSize of the stage.
+
+Making the producer a buffered channel and adjusting the buffer size allows
+any code that sends into the producers to execute without having to block wait
+on the pipeline to be ready, which in turn might improve the overall
+performance of the application by allowing more code to actually run in
+parallel.
+
+Similar to making the producer channel a buffered channel, you can also adjust
+the bufferSize of each stage in the pipeline. This is buffer size of the output
+channel. This allows the stage to proceed without having to block wait on the
+consumer being ready. And similar to the effect of having a buffered producer,
+this would potentially allow more code to run in parallel.
+
+The third dial that can affect the performance of a pipeline is the size of the
+worker pool. In theory, if the producer can saturate the worker pool, and the
+consumer can consume all of the output, then the throughput of each stage
+should scale linearly with with the size of the worker. However,  in reallity,
+this scaling is affected by many factors and will almost never simply be
+linear.
+
+Applications are recommended to run benchmarks with real workloads and tweak
+the setting to find the most suitable combination of producer and consumer
+buffer sizes and worker pool sizes.
+
+The Benchmark* methods in stage_test.go offers a good starting point on how
+to write such benchmark test cases.
 
 */
 package pipeline

--- a/pipeline.go
+++ b/pipeline.go
@@ -79,7 +79,7 @@ func NewPipelineWithProducer[I, O any](done <-chan struct{}, producer Producer[I
 // the list of stages of the current pipeline.
 //
 // This method throws a ErrNoProducer if the pipeline does not have a producer.
-func (p *Pipeline[I, O]) AddStage(workerPoolSize int,
+func (p *Pipeline[I, O]) AddStage(workerPoolSize int, bufferSize int,
 	worker Worker[any, any]) (*Pipeline[I, O], error) {
 	if p.producer == nil {
 		return nil, ErrNoProducer
@@ -110,7 +110,8 @@ func (p *Pipeline[I, O]) AddStage(workerPoolSize int,
 		producerFunc = p.stages[len(p.stages)-1].Produces
 	}
 
-	stage, err := NewStage(p.done, workerPoolSize, producerFunc(), worker)
+	stage, err := NewStage(p.done, workerPoolSize, bufferSize,
+		producerFunc(), worker)
 	if err != nil {
 		return nil, err
 	}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -45,7 +45,7 @@ func ExamplePipeline_Consumes() {
 	p.Consumes(producer)
 	p.WithConsumer(consumer)
 
-	_, err := p.AddStage(10, sq)
+	_, err := p.AddStage(10, 0, sq)
 	if err != nil {
 		log.Fatalf("Unable to add stage: %v", err)
 	}
@@ -80,7 +80,7 @@ func ExamplePipeline_Produces() {
 		return i * i
 	}
 	p, err := pipeline.NewPipelineWithProducer[int, int](done,
-		producer).AddStage(10, sq)
+		producer).AddStage(10, 0, sq)
 	if err != nil {
 		log.Fatalf("Unable to add stage: %v", err)
 	}
@@ -119,7 +119,7 @@ func ExamplePipeline_Produces_chaining() {
 		return i * i
 	}
 	p1, err := pipeline.NewPipelineWithProducer[int, int](done,
-		producer).AddStage(10, sq)
+		producer).AddStage(10, 0, sq)
 	if err != nil {
 		log.Fatalf("Unable to add stage: %v", err)
 	}
@@ -135,7 +135,7 @@ func ExamplePipeline_Produces_chaining() {
 	// We chain the output channel of p1 into p2 by using it as the producer of
 	// p2
 	p2, err := pipeline.NewPipelineWithProducer[int, int](done,
-		p1Producer).AddStage(10, cube)
+		p1Producer).AddStage(10, 0, cube)
 	p2.WithConsumer(consumer)
 
 	_, err = p2.Produces()
@@ -152,7 +152,7 @@ func TestPipeline_AddStage(t *testing.T) {
 	t.Run("Should return error when no producer is present", func(t *testing.T) {
 		done := make(chan struct{})
 		p := pipeline.NewPipeline[int, int](done)
-		if _, err := p.AddStage(1, func(input any) any {
+		if _, err := p.AddStage(1, 0, func(input any) any {
 			return input
 		}); err == nil {
 			t.Error("Expecting ErrNoProducer, got nil")

--- a/stage.go
+++ b/stage.go
@@ -21,6 +21,7 @@ import (
 
 // Errors for when the stage is in a invalid state
 var (
+	ErrInvalidBufferSize     = errors.New("invalid buffer size")
 	ErrInvalidWorkerPoolSize = errors.New("invalid worker pool size")
 )
 
@@ -61,14 +62,17 @@ type Stage[I, O any] struct {
 // This function returns ErrInvalidWorkerPoolSize if workerPoolSize is not at
 // least 1.
 func NewStage[I, O any](done <-chan struct{}, workerPoolSize int,
-	in Producer[I], worker Worker[I, O]) (*Stage[I, O], error) {
+	bufferSize int, in Producer[I], worker Worker[I, O]) (*Stage[I, O], error) {
 	if workerPoolSize < 1 {
 		return nil, ErrInvalidWorkerPoolSize
+	}
+	if bufferSize < 0 {
+		return nil, ErrInvalidBufferSize
 	}
 	return &Stage[I, O]{
 		done:           done,
 		in:             in,
-		out:            make(chan O),
+		out:            make(chan O, bufferSize),
 		workerPoolSize: workerPoolSize,
 		worker:         worker,
 	}, nil


### PR DESCRIPTION
This PR adds buffer support to the pipeline library.

This allows better performance tuning by tweaking the buffer size of the output channel.

Users can already tweak the buffer size of the input channel and the worker pool. By introducing the final missing piece, all aspects of a pipeline can be finely controlled.

This PR also includes all necessary documentation, test cases and benchmarking examples.