### PR TITLE
Mention known pkg.go.dev issue in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ main Go module:
 
 API documentation and example code can be found at
 [pkg.go.dev](https://pkg.go.dev/github.com/qqiao/pipeline).
+
+### Known issues
+
+- Currently, there is an bug with pkg.go.dev with regard to generics. 
+  Examples with generics are not correctly associated to their function 
+  signatures. This causes all the examples to be missing from pkg.go.dev. A 
+  simple workaround is to use `godoc` to read the documentation locally. 
+  Up-to-date local versions of `godoc` renders examples correctly.


### PR DESCRIPTION
Currently, there is an bug with pkg.go.dev with regard to generics.
Examples with generics are not correctly associated to their function
signatures. This causes all the examples to be missing from pkg.go.dev. A
simple workaround is to use `godoc` to read the documentation locally.
Up-to-date local versions of `godoc` renders examples correctly.