### PR TITLE
API Update and Thread Safety

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -1,0 +1,56 @@
+package pipeline
+
+import "context"
+
+// StreamWorker is a type of worker that continuously takes input from the
+// producer and continuously produces output into the output channel.
+//
+// A StreamWorker also returns an error channel, any time anything is sent
+// into this channel, the execution of the entire pipeline will halt
+// immediately. This is to ensure that the pipeline correctly maintains its
+// fail-fast characteristics.
+type StreamWorker[I, O any] func(context.Context, Producer[I]) (<-chan O,
+	<-chan error)
+
+// Worker represent a unit of work.
+//
+// Workers are simple functions that takes an input and returns an output. The
+// Stage will take care of the parallelization of workers and the combination
+// of the results.
+//
+// Since multiple Worker instances will be created, Worker functions are
+// expected to be thread-safe to prevent any unpredictable results.
+type Worker[I, O any] func(I) (O, error)
+
+// NewStreamWorker takes any Worker and converts it into a StreamWorker
+func NewStreamWorker[I, O any](worker Worker[I, O]) StreamWorker[I, O] {
+	return func(ctx context.Context, in Producer[I]) (<-chan O, <-chan error) {
+		output := make(chan O)
+		errCh := make(chan error)
+
+		_ctx, cancel := context.WithCancel(ctx)
+		go func() {
+			defer close(output)
+			defer close(errCh)
+			for {
+				select {
+				case i, ok := <-in:
+					if !ok {
+						return
+					}
+					out, err := worker(i)
+					if err != nil {
+						errCh <- err
+						cancel()
+						return
+					}
+					output <- out
+
+				case <-_ctx.Done():
+					return
+				}
+			}
+		}()
+		return output, errCh
+	}
+}


### PR DESCRIPTION
* Updated Stage and Pipeline API by introducing the StreamWorker API. This
API allows users to more freedom to create worker functions that continuously
read input from the producer and produces outputs.
This particular feature is especially useful in cases like database queries,
where the producer might be query parameters and worker need to return
multiple results matching the query criterion.

* Added thread safety. While we do not expect a pipeline to be modified by
multiple goroutines, we would not incur much penalty by introducing thread
safety nevertheless.
Therefore, all the AddStage* methods and now thread-safe. Meaning that they
can be called by different goroutines and there will not be any internal race
condition.
Moreover, the Start methods on both Stage and Pipeline are now re-entrant, so
they can be called multiple times by different goroutines.

Please note that it is still the users' responsibility to ensure that the
workers themselves are thread-safe.

A workaround for thread unsafe workers has been added to the package level
documentation.