### PR TITLE
Updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,3 @@ API documentation and example code can be found at
 [pkg.go.dev](https://pkg.go.dev/github.com/qqiao/pipeline).
 
 ### Known issues
-
-- Currently, there is an bug with pkg.go.dev with regard to generics. 
-  Examples with generics are not correctly associated to their function 
-  signatures. This causes all the examples to be missing from pkg.go.dev. A 
-  simple workaround is to use `godoc` to read the documentation locally. 
-  Up-to-date local versions of `godoc` renders examples correctly.


### PR DESCRIPTION
pkg.go.dev has been fixed and examples are now shown correctly.

Thus, removing the note in the known issues section.