### PR TITLE
Renamed cont to done

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,1 +1,2 @@
 FROM qqiao/gitpod-env:latest
+

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -308,12 +308,13 @@ func TestPipeline_Start_failFast(t *testing.T) {
 	errCh := p.Start(context.Background())
 
 	var err error
+
 	// If fail fast didn't happen, the following loop will infinite loop
-	for cont := true; cont; {
+	for done := false; !done; {
 		select {
 		case <-out:
 		case err = <-errCh:
-			cont = false
+			done = true
 		}
 	}
 

--- a/stage_test.go
+++ b/stage_test.go
@@ -322,11 +322,11 @@ func TestStage_Start(t *testing.T) {
 		errCh := stage.Start(context.Background())
 
 		// If fail fast didn't happen, the following loop will infinite loop
-		for cont := true; cont; {
+		for done := false; !done; {
 			select {
 			case <-out:
 			case err = <-errCh:
-				cont = false
+				done = true
 			}
 		}
 


### PR DESCRIPTION
In quite a few for-select loops, we initially named the condition to
cont, as in continue, however, this isn't immediately obvious to most,
so we are now changing it to done as this would be a more descriptive
variable name.